### PR TITLE
Add glfw dependency to install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ The scenic.new mix task, which generates out a starter application for you. This
 mix archive.install hex scenic_new
 ```
 
+To build and run scenic applications, you will also need to install a few dependencies. See the [Getting started](https://hexdocs.pm/scenic/getting_started.html#install-dependencies) for more information.
+
 ## Build the Starter App
 
 


### PR DESCRIPTION
I was anxious and went to scenic_new for instructions first. I added a link back to the getting started guide since there's so much more info there. Feel free to include or not.