### PR TITLE
ubuntu xenial (16.04) do not have libglew2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ Once these components have been installed, you should be able to build the `scen
 The easiest way to install on Ubuntu is to use apt-get. Just run the following:
 
 ```bash
-apt-get update
-apt-get install pkgconf libglfw3 libglfw3-dev libglew2.0 libglew-dev
+sudo apt-get update
+sudo apt-get install pkgconf libglfw3 libglfw3-dev libglew-dev
 ```
 
 Once these components have been installed, you should be able to build the `scenic_driver_glfw` driver.


### PR DESCRIPTION
It is better to ignore specific version of libglew and instead
install libglew-dev, which will take care of the specific version.
The changes works for me on Ubuntu Xenial (16.04) and should (hopefully)
work on later Ubuntu as well.