### PR TITLE
docs: add FreeBSD incantations

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,19 @@ sudo apt-get install pkgconf libglfw3 libglfw3-dev libglew2.0 libglew-dev
 Once these components have been installed, you should be able to build the
 `scenic_driver_glfw` driver.
 
+### Installing on FreeBSD
+
+The easiest way to install on FreeBSD is to use `pkg`. Just run the following,
+to install development toolchain, and build/runtime graphics libraries:
+
+```bash
+sudo pkg install devel/gmake devel/pkgconf devel/elixir-hex devel/rebar3 \
+  graphics/glew graphics/glfw
+```
+
+Once these components have been installed, you should be able to build the
+`scenic_driver_glfw` driver.
+
 ## Install `scenic.new`
 
 ```bash


### PR DESCRIPTION
tested on:

- 12.0-ALPHA8 amd64
- 11.2R amd64
- OTP20 & elixir 1.7.3

BTW there seems to be no issue running scenic with OTP 19 as baseline either. Neat!