### PR TITLE
Add live-reload to new_example

### DIFF
--- a/templates/new_example/config/config.exs.eex
+++ b/templates/new_example/config/config.exs.eex
@@ -16,6 +16,10 @@ config :<%= @app %>, :viewport, %{
   ]
 }
 
+# Configure reload callback of ExSync so that we are notified when a file is changed
+config :exsync,
+  reload_callback: {GenServer, :call, [<%= @mod %>.Component.Nav, :reload_current_scene]}
+
 # It is also possible to import configuration files, relative to this
 # directory. For example, you can emulate configuration per environment
 # by uncommenting the line below and defining dev.exs, test.exs and such.

--- a/templates/new_example/lib/components/nav.ex.eex
+++ b/templates/new_example/lib/components/nav.ex.eex
@@ -58,4 +58,10 @@ defmodule <%= @mod %>.Component.Nav do
     ViewPort.set_root(vp, scene)
     {:stop, state}
   end
+
+  def handle_call(:reload_current_scene, _, state) do
+    pid = Process.whereis(:scenic)
+    Process.exit(pid, :kill)
+    {:reply, nil, state}
+  end
 end

--- a/templates/new_example/mix.exs.eex
+++ b/templates/new_example/mix.exs.eex
@@ -25,6 +25,7 @@ defmodule <%= @mod %>.MixProject do
     [
       {:scenic, "~> 0.9"},
       {:scenic_driver_glfw, "~> 0.9"},
+      {:exsync, git: "https://github.com/falood/exsync.git", ref: "922622c"},
 
       # These deps are optional and are included as they are often used.
       # If your app doesn't need them, they are safe to remove.


### PR DESCRIPTION
The heavy lifting is done by exsync which supports both Mac and Linux
https://github.com/falood/exsync

Architecture

When exsync detects a file system change it recompiles the changed filed into
the BEAM. After this recompilation sequence finishes, it calls the configured
callback function which is handled in the `Nav` component. The `Nav` component
then restarts scenic by killing it's root process.

If there was an easy/non-invasive way to get the current scene then we could
restart just that instead of the entire process tree.

Note: currently relies on an unreleased version of exsync.