### PR TITLE
Update graph in `handle_info`

### DIFF
--- a/templates/new_example/lib/scenes/sensor.ex.eex
+++ b/templates/new_example/lib/scenes/sensor.ex.eex
@@ -92,7 +92,7 @@ defmodule <%= @mod %>.Scene.Sensor do
       # temperature = kelvin - 273                      # celcius
       |> :erlang.float_to_binary(decimals: 1)
 
-    graph
+    graph = graph
     # center the temperature on the viewport
     |> Graph.modify(:temperature, &text(&1, temperature <> @degrees))
     |> push_graph()


### PR DESCRIPTION
This isn't necessary for the example, but I was using this example as the basis for a project.  When I put in two sensors it was flashing back and forth between the two.  It took me a bit to realize that it was because it was always based on the graph from `init`.  This will hopefully prevent other people from having the same confusion.