### PR TITLE
Specify the glfw driver is for only host

### DIFF
--- a/templates/new/mix.exs.eex
+++ b/templates/new/mix.exs.eex
@@ -24,7 +24,7 @@ defmodule <%= @mod %>.MixProject do
   defp deps do
     [
       {:scenic, "~> 0.9"},
-      {:scenic_driver_glfw, "~> 0.9"},
+      {:scenic_driver_glfw, "~> 0.9", targets: :host},
     ]
   end
 end

--- a/templates/new_example/mix.exs.eex
+++ b/templates/new_example/mix.exs.eex
@@ -24,7 +24,7 @@ defmodule <%= @mod %>.MixProject do
   defp deps do
     [
       {:scenic, "~> 0.9"},
-      {:scenic_driver_glfw, "~> 0.9"},
+      {:scenic_driver_glfw, "~> 0.9", targets: :host},
 
       # These deps are optional and are included as they are often used.
       # If your app doesn't need them, they are safe to remove.

--- a/test/scenic_new_example_test.exs
+++ b/test/scenic_new_example_test.exs
@@ -51,7 +51,7 @@ defmodule Mix.Tasks.Scenic.NewExampleTest do
                  assert file =~ "mod: {#{@module_name}, []}"
 
                  assert file =~ "{:scenic, \"~> 0.9\"}"
-                 assert file =~ "{:scenic_driver_glfw, \"~> 0.9\"}"
+                 assert file =~ "{:scenic_driver_glfw, \"~> 0.9\", targets: :host}"
                end)
              end) =~ "Your Scenic project was created successfully."
     end)

--- a/test/scenic_new_test.exs
+++ b/test/scenic_new_test.exs
@@ -38,7 +38,7 @@ defmodule Mix.Tasks.Scenic.NewTest do
                  assert file =~ "mod: {#{@module_name}, []}"
 
                  assert file =~ "{:scenic, \"~> 0.9\"}"
-                 assert file =~ "{:scenic_driver_glfw, \"~> 0.9\"}"
+                 assert file =~ "{:scenic_driver_glfw, \"~> 0.9\", targets: :host}"
                end)
              end) =~ "Your Scenic project was created successfully."
     end)


### PR DESCRIPTION
Elixir 1.8 supports filtering the compile and runtime dependencies based on target. A pattern I've shaken out of this for use with Nerves is to create a separate application using `scenic.new` in a poncho project. for example from the top level:

```
my_proj
  my_proj_nerves
  my_proj_scenic
```

The issue with this structure in the past was that you would have to comment out the `scenic_driver_glfw` in the dependencies of `my_proj_scenic` when building `my_project_nerves` and uncomment it when running the `my_proj_scenic` on your host. With the addition of `targets` in the dependency options list, we can specify that it is only for `:host`. This will work for Elixir 1.8, pre 1.8 will simply ignore the option.

Once these two PRs are merged and released

https://github.com/nerves-project/nerves/pull/377
https://github.com/nerves-project/nerves_bootstrap/pull/92

We can circle around and updating the nerves specific one, but we might not need it anymore. 