### PR TITLE
Fix "celcius" typo in scenes/sensor.ex.eex

### DIFF
--- a/templates/new_example/lib/scenes/sensor.ex.eex
+++ b/templates/new_example/lib/scenes/sensor.ex.eex
@@ -89,7 +89,7 @@ defmodule <%= @mod %>.Scene.Sensor do
     # fahrenheit
     temperature =
       (9 / 5 * (kelvin - 273) + 32)
-      # temperature = kelvin - 273                      # celcius
+      # temperature = kelvin - 273                      # celsius
       |> :erlang.float_to_binary(decimals: 1)
 
     graph = graph


### PR DESCRIPTION
Tiny tiny contribution, but my eyes just landed on it while going through the code :sweat_smile: While I'm here, thanks a bazillion for this fantastic framework! :heart: 