### PR TITLE
Update the basic example to show the versions and use specs

### DIFF
--- a/templates/new/lib/scenes/home.ex.eex
+++ b/templates/new/lib/scenes/home.ex.eex
@@ -3,6 +3,7 @@ defmodule <%= @mod %>.Scene.Home do
   require Logger
 
   alias Scenic.Graph
+  alias Scenic.ViewPort
 
   import Scenic.Primitives
   # import Scenic.Components
@@ -15,24 +16,36 @@ defmodule <%= @mod %>.Scene.Home do
     mix scenic.new.example
   """
 
-  @graph Graph.build(font: :roboto, font_size: 24)
-  |> text(@note, translate: {20, 60})
-  # Transparent rectangle so that we receive cursor input (A scene is needed to
-  # capture cursor input)
-  # https://hexdocs.pm/scenic/Scenic.ViewPort.html#module-input
-  |> rect({700, 600})
+  @text_size 24
 
   # ============================================================================
   # setup
 
   # --------------------------------------------------------
-  def init(_, _) do
-    push_graph( @graph )
-    {:ok, @graph}
+  def init(_, opts) do
+    # get the width and height of the viewport. This is to demonstrate creating
+    # a transparent full-screen rectangle to catch user input
+    {:ok, %ViewPort.Status{size: {width, height}}} = ViewPort.info(opts[:viewport])
+
+    # show the version of scenic and the glfw driver
+    scenic_ver = Application.spec(:scenic, :vsn) |> to_string()
+    glfw_ver = Application.spec(:scenic, :vsn) |> to_string()
+
+    graph =
+      Graph.build(font: :roboto, font_size: @size)
+      |> add_specs_to_graph([
+        text_spec("scenic: v" <> scenic_ver, translate: {20, 40}),
+        text_spec("glfw: v" <> glfw_ver, translate: {20, 40 + @text_size}),
+        text_spec(@note, translate: {20, 120}),
+        rect_spec({width, height})
+      ])
+
+    push_graph(graph)
+    {:ok, graph}
   end
 
   def handle_input(event, _context, state) do
-    Logger.info "Received event: #{inspect(event)}"
+    Logger.info("Received event: #{inspect(event)}")
     {:noreply, state}
   end
 end

--- a/templates/new/mix.exs.eex
+++ b/templates/new/mix.exs.eex
@@ -23,7 +23,9 @@ defmodule <%= @mod %>.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:scenic, "~> 0.9"},
+      # will switch to 0.10 in preparation for release
+      # {:scenic, "~> 0.9"},
+      {:scenic, git: "https://github.com/boydm/scenic.git", override: true},
       {:scenic_driver_glfw, "~> 0.9", targets: :host},
     ]
   end


### PR DESCRIPTION
Update the basic example to point to master scenic (for now), show versions in the window and use specs.