### PR TITLE
Add targets: :host back for GLFW driver

### DIFF
--- a/templates/new/mix.exs.eex
+++ b/templates/new/mix.exs.eex
@@ -24,7 +24,7 @@ defmodule <%= @mod %>.MixProject do
   defp deps do
     [
       {:scenic, "~> 0.10"},
-      {:scenic_driver_glfw, "~> 0.10"},
+      {:scenic_driver_glfw, "~> 0.10", targets: :host},
     ]
   end
 end

--- a/templates/new_example/mix.exs.eex
+++ b/templates/new_example/mix.exs.eex
@@ -24,7 +24,7 @@ defmodule <%= @mod %>.MixProject do
   defp deps do
     [
       {:scenic, "~> 0.10"},
-      {:scenic_driver_glfw, "~> 0.10"},
+      {:scenic_driver_glfw, "~> 0.10", targets: :host},
 
       # These deps are optional and are included as they are often used.
       # If your app doesn't need them, they are safe to remove.

--- a/test/scenic_new_example_test.exs
+++ b/test/scenic_new_example_test.exs
@@ -52,7 +52,7 @@ defmodule Mix.Tasks.Scenic.NewExampleTest do
                  assert file =~ "mod: {#{@module_name}, []}"
 
                  assert file =~ "{:scenic, \"~> 0.10\"}"
-                 assert file =~ "{:scenic_driver_glfw, \"~> 0.10\"}"
+                 assert file =~ "{:scenic_driver_glfw, \"~> 0.10\", targets: :host}"
                end)
              end) =~ "Your Scenic project was created successfully."
     end)

--- a/test/scenic_new_test.exs
+++ b/test/scenic_new_test.exs
@@ -38,7 +38,7 @@ defmodule Mix.Tasks.Scenic.NewTest do
                  assert file =~ "mod: {#{@module_name}, []}"
 
                  assert file =~ "{:scenic, \"~> 0.10\"}"
-                 assert file =~ "{:scenic_driver_glfw, \"~> 0.10\"}"
+                 assert file =~ "{:scenic_driver_glfw, \"~> 0.10\", targets: :host}"
                end)
              end) =~ "Your Scenic project was created successfully."
     end)


### PR DESCRIPTION
This was removed in this commit, adding it back. https://github.com/boydm/scenic_new/commit/0db927441fb603906a12e01d603912406d35be1b#diff-8aaa06fb9094dd58b20583ce9cf78bc0

I have training at ElixirConf EU next Wednesday but already instructed people to prep their machines. I'll cover this in my slides for now.