### PR TITLE
Document how to install glew and glfw libraries on Fedora

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,18 @@ sudo pacman -S pkgconf glew glfw-x11
 Once these components have been installed, you should be able to build the
 `scenic_driver_glfw` driver.
 
+### Installing on Fedora
+
+The easiest way to install on Fedora is to use `dnf`. Just run the following,
+to install development toolchain, and build/runtime graphics libraries:
+
+```bash
+sudo dnf install pkgconf glew-devel glfw-devel
+```
+
+Once these components have been installed, you should be able to build the
+`scenic_driver_glfw` driver.
+
 ### Installing on FreeBSD
 
 The easiest way to install on FreeBSD is to use `pkg`. Just run the following,


### PR DESCRIPTION
I noticed that Fedora wasn't listed as an install target in the README.  This PR adds `dnf` command needed to install development libraries for `glew` and `glfw`.  I was able to build the driver and launch the app after installing them.

Thanks for scenic!