### PR TITLE
Use appropriate option from Application spec

### DIFF
--- a/templates/new/lib/scenes/home.ex.eex
+++ b/templates/new/lib/scenes/home.ex.eex
@@ -29,7 +29,7 @@ defmodule <%= @mod %>.Scene.Home do
 
     # show the version of scenic and the glfw driver
     scenic_ver = Application.spec(:scenic, :vsn) |> to_string()
-    glfw_ver = Application.spec(:scenic, :vsn) |> to_string()
+    glfw_ver = Application.spec(:scenic_driver_glfw, :vsn) |> to_string()
 
     graph =
       Graph.build(font: :roboto, font_size: @text_size)


### PR DESCRIPTION
The example is using the same value of :scenic from the App spec instead of the actual glfw version