### PR TITLE
Add generators

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,3 @@
+erlang 23.1
+elixir 1.11.2-otp-23
+nodejs 14.12.0

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ you. This is the easiest way to set up a new Scenic project.
 
 ## Erlang/Elixir versions
 
-Please note, it currently needs OTP 21 and Elixir 1.7. If you have trouble
-compiling, please check that you are running those versions first.
+Please note, it currently needs at least OTP 21 and Elixir 1.7. If you have
+trouble compiling, please check that you are running those versions first.
 
 ## Install Prerequisites
 
@@ -14,7 +14,7 @@ The design of Scenic goes to great lengths to minimize its dependencies to just
 the minimum. Namely, it needs Erlang/Elixir and OpenGL.
 
 Rendering your application into a window on your local computer (MacOS, Ubuntu
-and others) is done by the `scenic_driver_glfw` driver. It uses the GLFW and
+and others) is done by the `scenic_driver_local` driver. It uses the GLFW and
 GLEW libraries to connect to OpenGL.
 
 The instructions below assume you have already installed Elixir/Erlang. If you
@@ -32,7 +32,7 @@ brew install glfw3 glew pkg-config
 ```
 
 Once these components have been installed, you should be able to build the
-`scenic_driver_glfw` driver.
+`scenic_driver_local` driver.
 
 ### Installing on Ubuntu 16
 
@@ -44,7 +44,7 @@ sudo apt-get install pkgconf libglfw3 libglfw3-dev libglew1.13 libglew-dev
 ```
 
 Once these components have been installed, you should be able to build the
-`scenic_driver_glfw` driver.
+`scenic_driver_local` driver.
 
 ### Installing on Ubuntu 18
 
@@ -56,7 +56,7 @@ sudo apt-get install pkgconf libglfw3 libglfw3-dev libglew2.0 libglew-dev
 ```
 
 Once these components have been installed, you should be able to build the
-`scenic_driver_glfw` driver.
+`scenic_driver_local` driver.
 
 ### Installing on Arch Linux
 
@@ -67,7 +67,7 @@ sudo pacman -S pkgconf glew glfw-x11
 ```
 
 Once these components have been installed, you should be able to build the
-`scenic_driver_glfw` driver.
+`scenic_driver_local` driver.
 
 ### Installing on Fedora
 
@@ -79,7 +79,7 @@ sudo dnf install pkgconf glew-devel glfw-devel
 ```
 
 Once these components have been installed, you should be able to build the
-`scenic_driver_glfw` driver.
+`scenic_driver_local` driver.
 
 ### Installing on FreeBSD
 
@@ -92,7 +92,7 @@ sudo pkg install devel/gmake devel/pkgconf devel/elixir-hex devel/rebar3 \
 ```
 
 Once these components have been installed, you should be able to build the
-`scenic_driver_glfw` driver.
+`scenic_driver_local` driver.
 
 ### Installing on NixOS 18.09
 

--- a/lib/common.ex
+++ b/lib/common.ex
@@ -100,13 +100,7 @@ defmodule ScenicNew.Common do
     end
   end
 
-  def base_module, do: app_base(otp_app())
-  defp otp_app, do: Mix.Project.config() |> Keyword.fetch!(:app)
-
-  defp app_base(app) do
-    case Application.get_env(app, :namespace, app) do
-      ^app -> app |> to_string() |> Macro.camelize()
-      mod -> mod |> inspect()
-    end
+  def base_module do
+    Mix.Project.config() |> Keyword.fetch!(:app) |> Atom.to_string() |> Macro.camelize()
   end
 end

--- a/lib/common.ex
+++ b/lib/common.ex
@@ -77,7 +77,6 @@ defmodule ScenicNew.Common do
     end
   end
 
-
   def check_mod_name_availability!(name) do
     [name]
     |> Module.concat()

--- a/lib/common.ex
+++ b/lib/common.ex
@@ -100,13 +100,13 @@ defmodule ScenicNew.Common do
     end
   end
 
-
   def base_module, do: app_base(otp_app())
   defp otp_app, do: Mix.Project.config() |> Keyword.fetch!(:app)
+
   defp app_base(app) do
     case Application.get_env(app, :namespace, app) do
       ^app -> app |> to_string() |> Macro.camelize()
-      mod  -> mod |> inspect()
+      mod -> mod |> inspect()
     end
   end
 end

--- a/lib/common.ex
+++ b/lib/common.ex
@@ -77,13 +77,6 @@ defmodule ScenicNew.Common do
     end
   end
 
-  def check_mod_name_validity!(name) when is_atom(name) do
-    unless Atom.to_string(name) =~ Regex.recompile!(~r/^[A-Z]\w*(\.[A-Z]\w*)*$/) do
-      Mix.raise(
-        "Module name must be a valid Elixir alias (for example: Foo.Bar), got: #{inspect(name)}"
-      )
-    end
-  end
 
   def check_mod_name_availability!(name) do
     [name]

--- a/lib/common.ex
+++ b/lib/common.ex
@@ -4,7 +4,7 @@
 #
 
 # A module to hold terms that represent the static file assets.
-# better to do this once than load them repeatedly into the 
+# better to do this once than load them repeatedly into the
 # different "new" types.
 
 defmodule ScenicNew.Common do
@@ -97,6 +97,16 @@ defmodule ScenicNew.Common do
 
     if File.dir?(path) and not Mix.shell().yes?(msg) do
       Mix.raise("Please select another directory for installation")
+    end
+  end
+
+
+  def base_module, do: app_base(otp_app())
+  defp otp_app, do: Mix.Project.config() |> Keyword.fetch!(:app)
+  defp app_base(app) do
+    case Application.get_env(app, :namespace, app) do
+      ^app -> app |> to_string() |> Macro.camelize()
+      mod  -> mod |> inspect()
     end
   end
 end

--- a/lib/common.ex
+++ b/lib/common.ex
@@ -69,8 +69,16 @@ defmodule ScenicNew.Common do
     end
   end
 
-  def check_mod_name_validity!(name) do
+  def check_mod_name_validity!(name) when is_binary(name) do
     unless name =~ Regex.recompile!(~r/^[A-Z]\w*(\.[A-Z]\w*)*$/) do
+      Mix.raise(
+        "Module name must be a valid Elixir alias (for example: Foo.Bar), got: #{inspect(name)}"
+      )
+    end
+  end
+
+  def check_mod_name_validity!(name) when is_atom(name) do
+    unless Atom.to_string(name) =~ Regex.recompile!(~r/^[A-Z]\w*(\.[A-Z]\w*)*$/) do
       Mix.raise(
         "Module name must be a valid Elixir alias (for example: Foo.Bar), got: #{inspect(name)}"
       )

--- a/lib/mix/tasks/new.ex
+++ b/lib/mix/tasks/new.ex
@@ -140,6 +140,7 @@ defmodule Mix.Tasks.Scenic.New do
     create_directory("lib")
     create_directory("lib/components")
     create_file("lib/#{app}.ex", app_template(assigns))
+    create_file("lib/assets.ex", assets_template(assigns))
 
     create_directory("lib/scenes")
     create_file("lib/scenes/home.ex", scene_home_template(assigns))
@@ -187,6 +188,7 @@ defmodule Mix.Tasks.Scenic.New do
     mix_exs: "templates/new/mix.exs.eex",
     config: "templates/new/config/config.exs.eex",
     app: "templates/new/lib/app.ex.eex",
+    assets: "templates/new/lib/assets.ex.eex",
     scene_home: "templates/new/lib/scenes/home.ex.eex"
   ]
 

--- a/lib/mix/tasks/scenic.gen.component.ex
+++ b/lib/mix/tasks/scenic.gen.component.ex
@@ -42,17 +42,10 @@ defmodule Mix.Tasks.Scenic.Gen.Component do
 
   # --------------------------------------------------------
   defp generate(component_filename, component_module) do
-    assigns = [
-      app_module_name: Common.base_module(),
-      component_module_name: component_module
-    ]
-
     component_path = "lib/components/#{component_filename}.ex"
-
     create_directory("lib/components")
-    create_file(component_path, component_new_template(assigns))
-
-    Mix.shell().info("Created component #{component_filename}.")
+    create_file(component_path, component_new_template(component_module: component_module))
+    Mix.shell().info("Created component #{component_module}.")
   end
 
   # ============================================================================

--- a/lib/mix/tasks/scenic.gen.component.ex
+++ b/lib/mix/tasks/scenic.gen.component.ex
@@ -32,11 +32,10 @@ defmodule Mix.Tasks.Scenic.Gen.Component do
 
       [component_module | _] ->
         Common.elixir_version_check!()
-        file_name = Macro.underscore(opts[:module] || component_module)
-        module = Module.concat([opts[:app] || Common.base_module(), "Component", component_module])
-        Common.check_mod_name_validity!(module)
-        Common.check_mod_name_availability!(module)
-        generate(file_name, module)
+        file_name = Macro.underscore(component_module)
+        app_module = opts[:app] || Common.base_module()
+        full_module = Module.concat([app_module, "Component", component_module])
+        generate(file_name, component_module, full_module)
     end
   end
 

--- a/lib/mix/tasks/scenic.gen.component.ex
+++ b/lib/mix/tasks/scenic.gen.component.ex
@@ -18,19 +18,21 @@ defmodule Mix.Tasks.Scenic.Gen.Component do
     module: :string
   ]
 
+  @task "scenic.gen.component"
 
   # --------------------------------------------------------
   @doc false
   def run(argv) do
     if Mix.Project.umbrella?() do
-      Mix.raise "mix scenic.gen.component must be invoked from within your scenic application root directory."
+      message = "mix #{@task} must be invoked from within your scenic application root directory."
+      Mix.raise(message)
     end
 
     {opts, argv} = OptionParser.parse!(argv, strict: @switches)
 
     case argv do
       [] ->
-        Mix.Tasks.Help.run(["scenic.gen.component"])
+        Mix.Tasks.Help.run([@task])
 
       [component_module_name | _] ->
 

--- a/lib/mix/tasks/scenic.gen.component.ex
+++ b/lib/mix/tasks/scenic.gen.component.ex
@@ -18,12 +18,13 @@ defmodule Mix.Tasks.Scenic.Gen.Component do
     module: :string
   ]
 
-
   # --------------------------------------------------------
   @doc false
   def run(argv) do
     if Mix.Project.umbrella?() do
-      Mix.raise "mix scenic.gen.component must be invoked from within your scenic application root directory."
+      Mix.raise(
+        "mix scenic.gen.component must be invoked from within your scenic application root directory."
+      )
     end
 
     {opts, argv} = OptionParser.parse!(argv, strict: @switches)
@@ -33,7 +34,6 @@ defmodule Mix.Tasks.Scenic.Gen.Component do
         Mix.Tasks.Help.run(["scenic.gen.component"])
 
       [component_module_name | _] ->
-
         Common.elixir_version_check!()
         file_name = opts[:module] || Macro.underscore(component_module_name)
         mod_name = opts[:app] || component_module_name
@@ -48,7 +48,8 @@ defmodule Mix.Tasks.Scenic.Gen.Component do
   # --------------------------------------------------------
   defp generate(component_filename, component_module) do
     assigns = [
-      app_module_name: Common.base_module(), #TOD: Figure out the right module name.
+      # TOD: Figure out the right module name.
+      app_module_name: Common.base_module(),
       component_module_name: component_module
     ]
 

--- a/lib/mix/tasks/scenic.gen.component.ex
+++ b/lib/mix/tasks/scenic.gen.component.ex
@@ -5,7 +5,7 @@ defmodule Mix.Tasks.Scenic.Gen.Component do
   Generates Scene boilerplate for a new component.
 
   ```bash
-  mix scenic.gen.component component_name
+  mix scenic.gen.component ComponentName
   ```
   """
   use Mix.Task

--- a/lib/mix/tasks/scenic.gen.component.ex
+++ b/lib/mix/tasks/scenic.gen.component.ex
@@ -13,7 +13,7 @@ defmodule Mix.Tasks.Scenic.Gen.Component do
   import Mix.Generator
   alias ScenicNew.Common
 
-  @switches [app: :string, module: :string]
+  @switches [app: :string]
 
   @task "scenic.gen.component"
   # --------------------------------------------------------

--- a/lib/mix/tasks/scenic.gen.component.ex
+++ b/lib/mix/tasks/scenic.gen.component.ex
@@ -1,0 +1,74 @@
+defmodule Mix.Tasks.Scenic.Gen.Component do
+  @shortdoc "Creates scaffolding for a new Scenic component."
+
+  @moduledoc """
+  Generates Scene boilerplate for a new component.
+
+  ```bash
+  mix scenic.gen.component component_name
+  ```
+  """
+  use Mix.Task
+
+  import Mix.Generator
+  alias ScenicNew.Common
+
+  @switches [
+    app: :string,
+    module: :string
+  ]
+
+
+  # --------------------------------------------------------
+  @doc false
+  def run(argv) do
+    {opts, argv} = OptionParser.parse!(argv, strict: @switches)
+
+    case argv do
+      [] ->
+        Mix.Tasks.Help.run(["scenic.gen.component"])
+
+      [component_name | _] ->
+
+        Common.elixir_version_check!()
+        app = opts[:app] || Path.basename(Path.expand(component_name))
+        Common.check_application_name!(app, !opts[:app])
+        mod = opts[:module] || Macro.camelize(app)
+        Common.check_mod_name_validity!(mod)
+        Common.check_mod_name_availability!(mod)
+
+        generate(app, mod)
+    end
+  end
+
+  # --------------------------------------------------------
+  defp generate(component_filename, component_module) do
+    if Mix.Project.umbrella?() do
+      Mix.raise "mix scenic.gen.component must be invoked from within your scenic application root directory."
+    end
+
+    assigns = [
+      app_module_name: Common.base_module(), #TOD: Figure out the right module name.
+      component_module_name: component_module
+    ]
+
+    component_path = "lib/components/#{component_filename}.ex"
+
+    create_directory("lib/components")
+    create_file(component_path, component_new_template(assigns))
+
+    """
+    Created component #{component_filename}.
+    """
+    |> Mix.shell().info()
+  end
+
+  # ============================================================================
+  # template files
+  [
+    component_new: "templates/gen_component/lib/components/component.ex.eex"
+  ]
+  |> Enum.each(fn {name, content} ->
+    embed_template(name, from_file: content)
+  end)
+end

--- a/lib/mix/tasks/scenic.gen.component.ex
+++ b/lib/mix/tasks/scenic.gen.component.ex
@@ -48,7 +48,6 @@ defmodule Mix.Tasks.Scenic.Gen.Component do
   # --------------------------------------------------------
   defp generate(component_filename, component_module) do
     assigns = [
-      # TOD: Figure out the right module name.
       app_module_name: Common.base_module(),
       component_module_name: component_module
     ]

--- a/lib/mix/tasks/scenic.gen.component.ex
+++ b/lib/mix/tasks/scenic.gen.component.ex
@@ -33,15 +33,13 @@ defmodule Mix.Tasks.Scenic.Gen.Component do
       [] ->
         Mix.Tasks.Help.run([@task])
 
-      [component_module_name | _] ->
+      [component_module | _] ->
         Common.elixir_version_check!()
-        file_name = opts[:module] || Macro.underscore(component_module_name)
-        mod_name = opts[:app] || component_module_name
-
-        Common.check_mod_name_validity!(mod_name)
-        Common.check_mod_name_availability!(mod_name)
-
-        generate(file_name, mod_name)
+        file_name = Macro.underscore(opts[:module] || component_module)
+        module = Module.concat([opts[:app] || Common.base_module(), "Component", component_module])
+        Common.check_mod_name_validity!(module)
+        Common.check_mod_name_availability!(module)
+        generate(file_name, module)
     end
   end
 

--- a/lib/mix/tasks/scenic.gen.component.ex
+++ b/lib/mix/tasks/scenic.gen.component.ex
@@ -32,16 +32,16 @@ defmodule Mix.Tasks.Scenic.Gen.Component do
       [] ->
         Mix.Tasks.Help.run(["scenic.gen.component"])
 
-      [component_name | _] ->
+      [component_module_name | _] ->
 
         Common.elixir_version_check!()
-        app = opts[:app] || Path.basename(Path.expand(component_name))
-        Common.check_application_name!(app, !opts[:app])
-        mod = opts[:module] || Macro.camelize(app)
-        Common.check_mod_name_validity!(mod)
-        Common.check_mod_name_availability!(mod)
+        file_name = opts[:module] || Macro.underscore(component_module_name)
+        mod_name = opts[:app] || component_module_name
 
-        generate(app, mod)
+        Common.check_mod_name_validity!(mod_name)
+        Common.check_mod_name_availability!(mod_name)
+
+        generate(file_name, mod_name)
     end
   end
 

--- a/lib/mix/tasks/scenic.gen.component.ex
+++ b/lib/mix/tasks/scenic.gen.component.ex
@@ -22,6 +22,10 @@ defmodule Mix.Tasks.Scenic.Gen.Component do
   # --------------------------------------------------------
   @doc false
   def run(argv) do
+    if Mix.Project.umbrella?() do
+      Mix.raise "mix scenic.gen.component must be invoked from within your scenic application root directory."
+    end
+
     {opts, argv} = OptionParser.parse!(argv, strict: @switches)
 
     case argv do
@@ -43,10 +47,6 @@ defmodule Mix.Tasks.Scenic.Gen.Component do
 
   # --------------------------------------------------------
   defp generate(component_filename, component_module) do
-    if Mix.Project.umbrella?() do
-      Mix.raise "mix scenic.gen.component must be invoked from within your scenic application root directory."
-    end
-
     assigns = [
       app_module_name: Common.base_module(), #TOD: Figure out the right module name.
       component_module_name: component_module

--- a/lib/mix/tasks/scenic.gen.component.ex
+++ b/lib/mix/tasks/scenic.gen.component.ex
@@ -44,8 +44,9 @@ defmodule Mix.Tasks.Scenic.Gen.Component do
   defp generate(component_filename, component_module) do
     component_path = "lib/components/#{component_filename}.ex"
     create_directory("lib/components")
-    create_file(component_path, component_new_template(component_module: component_module))
-    Mix.shell().info("Created component #{component_module}.")
+    create_file(component_path, component_new_template(component_module: inspect(component_module)))
+    component_name = component_module |> Module.split() |> Enum.reverse() |> hd()
+    Mix.shell().info("Created component #{component_name}.")
   end
 
   # ============================================================================

--- a/lib/mix/tasks/scenic.gen.component.ex
+++ b/lib/mix/tasks/scenic.gen.component.ex
@@ -13,10 +13,7 @@ defmodule Mix.Tasks.Scenic.Gen.Component do
   import Mix.Generator
   alias ScenicNew.Common
 
-  @switches [
-    app: :string,
-    module: :string
-  ]
+  @switches [app: :string, module: :string]
 
   @task "scenic.gen.component"
   # --------------------------------------------------------

--- a/lib/mix/tasks/scenic.gen.component.ex
+++ b/lib/mix/tasks/scenic.gen.component.ex
@@ -59,10 +59,7 @@ defmodule Mix.Tasks.Scenic.Gen.Component do
     create_directory("lib/components")
     create_file(component_path, component_new_template(assigns))
 
-    """
-    Created component #{component_filename}.
-    """
-    |> Mix.shell().info()
+    Mix.shell().info("Created component #{component_filename}.")
   end
 
   # ============================================================================

--- a/lib/mix/tasks/scenic.gen.component.ex
+++ b/lib/mix/tasks/scenic.gen.component.ex
@@ -44,7 +44,20 @@ defmodule Mix.Tasks.Scenic.Gen.Component do
     component_path = "lib/components/#{component_filename}.ex"
     create_directory("lib/components")
     create_file(component_path, component_new_template(component_module: inspect(full_module)))
-    Mix.shell().info("Created component #{component_module}.")
+
+    Mix.shell().info("""
+    Created component #{component_module}.
+
+    You can add it to your scene with:
+
+    graph
+    |> MyApp.Component.#{component_module}.add_to_graph(
+      "My Component",
+      translate: {100, 100}
+    )
+
+    Note: ensure that push_graph is called after the component is added to the graph.
+    """)
   end
 
   # ============================================================================

--- a/lib/mix/tasks/scenic.gen.component.ex
+++ b/lib/mix/tasks/scenic.gen.component.ex
@@ -40,12 +40,11 @@ defmodule Mix.Tasks.Scenic.Gen.Component do
   end
 
   # --------------------------------------------------------
-  defp generate(component_filename, component_module) do
+  defp generate(component_filename, component_module, full_module) do
     component_path = "lib/components/#{component_filename}.ex"
     create_directory("lib/components")
-    create_file(component_path, component_new_template(component_module: inspect(component_module)))
-    component_name = component_module |> Module.split() |> Enum.reverse() |> hd()
-    Mix.shell().info("Created component #{component_name}.")
+    create_file(component_path, component_new_template(component_module: inspect(full_module)))
+    Mix.shell().info("Created component #{component_module}.")
   end
 
   # ============================================================================

--- a/lib/mix/tasks/scenic.gen.scene.ex
+++ b/lib/mix/tasks/scenic.gen.scene.ex
@@ -32,12 +32,10 @@ defmodule Mix.Tasks.Scenic.Gen.Scene do
 
       [scene_module | _] ->
         Common.elixir_version_check!()
-        file_name = Macro.underscore(opts[:module] || scene_module)
-        module = Module.concat([opts[:app] || Common.base_module(), "Scene", scene_module])
-
-        Common.check_mod_name_validity!(module)
-        Common.check_mod_name_availability!(module)
-        generate(file_name, module)
+        file_name = Macro.underscore(scene_module)
+        app_module = opts[:app] || Common.base_module()
+        full_module = Module.concat([app_module, "Scene", scene_module])
+        generate(file_name, scene_module, full_module)
     end
   end
 

--- a/lib/mix/tasks/scenic.gen.scene.ex
+++ b/lib/mix/tasks/scenic.gen.scene.ex
@@ -40,12 +40,11 @@ defmodule Mix.Tasks.Scenic.Gen.Scene do
   end
 
   # --------------------------------------------------------
-  defp generate(scene_filename, scene_module) do
+  defp generate(scene_filename, scene_module, full_module) do
     scene_path = "lib/scenes/#{scene_filename}.ex"
     create_directory("lib/scenes")
-    create_file(scene_path, scene_new_template(scene_module: inspect(scene_module)))
-    scene_name = scene_module |> Module.split() |> Enum.reverse() |> hd()
-    Mix.shell().info("Created scene #{scene_name}.")
+    create_file(scene_path, scene_new_template(scene_module: full_module))
+    Mix.shell().info("Created scene #{scene_module}.")
   end
 
   # ============================================================================

--- a/lib/mix/tasks/scenic.gen.scene.ex
+++ b/lib/mix/tasks/scenic.gen.scene.ex
@@ -13,10 +13,7 @@ defmodule Mix.Tasks.Scenic.Gen.Scene do
   import Mix.Generator
   alias ScenicNew.Common
 
-  @switches [
-    app: :string,
-    module: :string
-  ]
+  @switches [app: :string, module: :string]
 
   @task "scenic.gen.scene"
   # --------------------------------------------------------

--- a/lib/mix/tasks/scenic.gen.scene.ex
+++ b/lib/mix/tasks/scenic.gen.scene.ex
@@ -22,6 +22,10 @@ defmodule Mix.Tasks.Scenic.Gen.Scene do
   # --------------------------------------------------------
   @doc false
   def run(argv) do
+    if Mix.Project.umbrella?() do
+      Mix.raise "mix scenic.gen.component must be invoked from within your scenic application root directory."
+    end
+
     {opts, argv} = OptionParser.parse!(argv, strict: @switches)
 
     case argv do
@@ -43,10 +47,6 @@ defmodule Mix.Tasks.Scenic.Gen.Scene do
 
   # --------------------------------------------------------
   defp generate(scene_filename, scene_module) do
-    if Mix.Project.umbrella?() do
-      Mix.raise "mix scenic.gen.scene must be invoked from within your scenic application root directory."
-    end
-
     assigns = [
       app_module_name: Common.base_module(), #TOD: Figure out the right module name.
       scene_module_name: scene_module

--- a/lib/mix/tasks/scenic.gen.scene.ex
+++ b/lib/mix/tasks/scenic.gen.scene.ex
@@ -13,7 +13,7 @@ defmodule Mix.Tasks.Scenic.Gen.Scene do
   import Mix.Generator
   alias ScenicNew.Common
 
-  @switches [app: :string, module: :string]
+  @switches [app: :string]
 
   @task "scenic.gen.scene"
   # --------------------------------------------------------

--- a/lib/mix/tasks/scenic.gen.scene.ex
+++ b/lib/mix/tasks/scenic.gen.scene.ex
@@ -1,0 +1,71 @@
+defmodule Mix.Tasks.Scenic.Gen.Scene do
+  @shortdoc "Creates scaffolding for a new Scenic scene."
+
+  @moduledoc """
+  Generates Scene boilerplate for a new scene.
+
+  ```bash
+  mix scenic.gen.scene scene_name
+  ```
+  """
+  use Mix.Task
+
+  import Mix.Generator
+  alias ScenicNew.Common
+
+  @switches [
+    app: :string,
+    module: :string
+  ]
+
+  # --------------------------------------------------------
+  @doc false
+  def run(argv) do
+    {opts, argv} = OptionParser.parse!(argv, strict: @switches)
+
+    case argv do
+      [] ->
+        Mix.Tasks.Help.run(["scenic.gen.scene"])
+
+      [scene_name | _] ->
+
+        Common.elixir_version_check!()
+        app = opts[:app] || Path.basename(Path.expand(scene_name))
+        Common.check_application_name!(app, !opts[:app])
+        mod = opts[:module] || Macro.camelize(app)
+        Common.check_mod_name_validity!(mod)
+        Common.check_mod_name_availability!(mod)
+
+        generate(app, mod)
+    end
+  end
+
+  # --------------------------------------------------------
+  defp generate(component_filename, component_module) do
+
+    assigns = [
+      app_module_name: component_module, #TOD: Figure out the right module name.
+      scene_module_name: component_module
+    ]
+
+    component_path = "lib/scenes/#{component_filename}.ex"
+    #IO.puts("Generating at #{component_filename} #{component_module} #{component_path}")
+
+    create_directory("lib/scenes")
+    create_file(component_path, scene_new_template(assigns))
+
+    """
+    Created component #{component_filename}.
+    """
+    |> Mix.shell().info()
+  end
+
+  # ============================================================================
+  # template files
+  [
+    scene_new: "templates/gen_scene/lib/scenes/scene.ex.eex"
+  ]
+  |> Enum.each(fn {name, content} ->
+    embed_template(name, from_file: content)
+  end)
+end

--- a/lib/mix/tasks/scenic.gen.scene.ex
+++ b/lib/mix/tasks/scenic.gen.scene.ex
@@ -18,6 +18,7 @@ defmodule Mix.Tasks.Scenic.Gen.Scene do
     module: :string
   ]
 
+
   # --------------------------------------------------------
   @doc false
   def run(argv) do
@@ -42,14 +43,16 @@ defmodule Mix.Tasks.Scenic.Gen.Scene do
 
   # --------------------------------------------------------
   defp generate(component_filename, component_module) do
+    if Mix.Project.umbrella?() do
+      Mix.raise "mix scenic.gen.scene must be invoked from within your scenic application root directory."
+    end
 
     assigns = [
-      app_module_name: component_module, #TOD: Figure out the right module name.
+      app_module_name: Common.base_module(), #TOD: Figure out the right module name.
       scene_module_name: component_module
     ]
 
     component_path = "lib/scenes/#{component_filename}.ex"
-    #IO.puts("Generating at #{component_filename} #{component_module} #{component_path}")
 
     create_directory("lib/scenes")
     create_file(component_path, scene_new_template(assigns))

--- a/lib/mix/tasks/scenic.gen.scene.ex
+++ b/lib/mix/tasks/scenic.gen.scene.ex
@@ -42,23 +42,23 @@ defmodule Mix.Tasks.Scenic.Gen.Scene do
   end
 
   # --------------------------------------------------------
-  defp generate(component_filename, component_module) do
+  defp generate(scene_filename, scene_module) do
     if Mix.Project.umbrella?() do
       Mix.raise "mix scenic.gen.scene must be invoked from within your scenic application root directory."
     end
 
     assigns = [
       app_module_name: Common.base_module(), #TOD: Figure out the right module name.
-      scene_module_name: component_module
+      scene_module_name: scene_module
     ]
 
-    component_path = "lib/scenes/#{component_filename}.ex"
+    scene_path = "lib/scenes/#{scene_filename}.ex"
 
     create_directory("lib/scenes")
-    create_file(component_path, scene_new_template(assigns))
+    create_file(scene_path, scene_new_template(assigns))
 
     """
-    Created component #{component_filename}.
+    Created scene #{scene_path}.
     """
     |> Mix.shell().info()
   end

--- a/lib/mix/tasks/scenic.gen.scene.ex
+++ b/lib/mix/tasks/scenic.gen.scene.ex
@@ -33,14 +33,13 @@ defmodule Mix.Tasks.Scenic.Gen.Scene do
       [] ->
         Mix.Tasks.Help.run(["scenic.gen.scene"])
 
-      [scene_module_name | _] ->
+      [scene_module | _] ->
         Common.elixir_version_check!()
-        file_name = opts[:module] || Macro.underscore(scene_module_name)
-        mod_name = opts[:app] || scene_module_name
-        Common.check_mod_name_validity!(mod_name)
-        Common.check_mod_name_availability!(mod_name)
-
-        generate(file_name, mod_name)
+        file_name = Macro.underscore(opts[:module] || scene_module)
+        module = Module.concat([opts[:app] || Common.base_module(), "Scene", scene_module])
+        Common.check_mod_name_validity!(module)
+        Common.check_mod_name_availability!(module)
+        generate(file_name, module)
     end
   end
 

--- a/lib/mix/tasks/scenic.gen.scene.ex
+++ b/lib/mix/tasks/scenic.gen.scene.ex
@@ -5,7 +5,7 @@ defmodule Mix.Tasks.Scenic.Gen.Scene do
   Generates Scene boilerplate for a new scene.
 
   ```bash
-  mix scenic.gen.scene scene_name
+  mix scenic.gen.scene SceneName
   ```
   """
   use Mix.Task

--- a/lib/mix/tasks/scenic.gen.scene.ex
+++ b/lib/mix/tasks/scenic.gen.scene.ex
@@ -47,7 +47,6 @@ defmodule Mix.Tasks.Scenic.Gen.Scene do
   # --------------------------------------------------------
   defp generate(scene_filename, scene_module) do
     assigns = [
-      # TOD: Figure out the right module name.
       app_module_name: Common.base_module(),
       scene_module_name: scene_module
     ]

--- a/lib/mix/tasks/scenic.gen.scene.ex
+++ b/lib/mix/tasks/scenic.gen.scene.ex
@@ -18,12 +18,13 @@ defmodule Mix.Tasks.Scenic.Gen.Scene do
     module: :string
   ]
 
-
   # --------------------------------------------------------
   @doc false
   def run(argv) do
     if Mix.Project.umbrella?() do
-      Mix.raise "mix scenic.gen.component must be invoked from within your scenic application root directory."
+      Mix.raise(
+        "mix scenic.gen.component must be invoked from within your scenic application root directory."
+      )
     end
 
     {opts, argv} = OptionParser.parse!(argv, strict: @switches)
@@ -33,7 +34,6 @@ defmodule Mix.Tasks.Scenic.Gen.Scene do
         Mix.Tasks.Help.run(["scenic.gen.scene"])
 
       [scene_module_name | _] ->
-
         Common.elixir_version_check!()
         file_name = opts[:module] || Macro.underscore(scene_module_name)
         mod_name = opts[:app] || scene_module_name
@@ -47,7 +47,8 @@ defmodule Mix.Tasks.Scenic.Gen.Scene do
   # --------------------------------------------------------
   defp generate(scene_filename, scene_module) do
     assigns = [
-      app_module_name: Common.base_module(), #TOD: Figure out the right module name.
+      # TOD: Figure out the right module name.
+      app_module_name: Common.base_module(),
       scene_module_name: scene_module
     ]
 

--- a/lib/mix/tasks/scenic.gen.scene.ex
+++ b/lib/mix/tasks/scenic.gen.scene.ex
@@ -42,20 +42,10 @@ defmodule Mix.Tasks.Scenic.Gen.Scene do
 
   # --------------------------------------------------------
   defp generate(scene_filename, scene_module) do
-    assigns = [
-      app_module_name: Common.base_module(),
-      scene_module_name: scene_module
-    ]
-
     scene_path = "lib/scenes/#{scene_filename}.ex"
-
     create_directory("lib/scenes")
-    create_file(scene_path, scene_new_template(assigns))
-
-    """
-    Created scene #{scene_path}.
-    """
-    |> Mix.shell().info()
+    create_file(scene_path, scene_new_template(scene_module: scene_module))
+    Mix.shell().info("Created scene #{scene_module}.")
   end
 
   # ============================================================================

--- a/lib/mix/tasks/scenic.gen.scene.ex
+++ b/lib/mix/tasks/scenic.gen.scene.ex
@@ -34,6 +34,7 @@ defmodule Mix.Tasks.Scenic.Gen.Scene do
         Common.elixir_version_check!()
         file_name = Macro.underscore(opts[:module] || scene_module)
         module = Module.concat([opts[:app] || Common.base_module(), "Scene", scene_module])
+
         Common.check_mod_name_validity!(module)
         Common.check_mod_name_availability!(module)
         generate(file_name, module)
@@ -44,8 +45,9 @@ defmodule Mix.Tasks.Scenic.Gen.Scene do
   defp generate(scene_filename, scene_module) do
     scene_path = "lib/scenes/#{scene_filename}.ex"
     create_directory("lib/scenes")
-    create_file(scene_path, scene_new_template(scene_module: scene_module))
-    Mix.shell().info("Created scene #{scene_module}.")
+    create_file(scene_path, scene_new_template(scene_module: inspect(scene_module)))
+    scene_name = scene_module |> Module.split() |> Enum.reverse() |> hd()
+    Mix.shell().info("Created scene #{scene_name}.")
   end
 
   # ============================================================================

--- a/lib/mix/tasks/scenic.gen.scene.ex
+++ b/lib/mix/tasks/scenic.gen.scene.ex
@@ -32,16 +32,15 @@ defmodule Mix.Tasks.Scenic.Gen.Scene do
       [] ->
         Mix.Tasks.Help.run(["scenic.gen.scene"])
 
-      [scene_name | _] ->
+      [scene_module_name | _] ->
 
         Common.elixir_version_check!()
-        app = opts[:app] || Path.basename(Path.expand(scene_name))
-        Common.check_application_name!(app, !opts[:app])
-        mod = opts[:module] || Macro.camelize(app)
-        Common.check_mod_name_validity!(mod)
-        Common.check_mod_name_availability!(mod)
+        file_name = opts[:module] || Macro.underscore(scene_module_name)
+        mod_name = opts[:app] || scene_module_name
+        Common.check_mod_name_validity!(mod_name)
+        Common.check_mod_name_availability!(mod_name)
 
-        generate(app, mod)
+        generate(file_name, mod_name)
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -52,7 +52,7 @@ defmodule ScenicNew.MixProject do
   # Run "mix help compile.app" to learn about applications.
   def application do
     [
-      extra_applications: []
+      extra_applications: [:eex]
     ]
   end
 

--- a/templates/gen_component/lib/components/component.ex.eex
+++ b/templates/gen_component/lib/components/component.ex.eex
@@ -6,18 +6,18 @@ defmodule <%= @app_module_name %>.Components.<%= @component_module_name %> do
     @graph Graph.build()
     |> text("", text_align: :center, translate: {100, 200}, id: :text)
 
-    # TODO: Explanation of info/1 callback here.
+    @impl Scenic.Component
     def info( data ), do: """
     #{IO.ANSI.red()}#{__MODULE__} data must be a bitstring
     #{IO.ANSI.yellow()}Received: #{inspect(data)}
     #{IO.ANSI.default_color()}
     """
 
-    # TODO: Explanation of verify/1 callback here.
+    @impl Scenic.Component
     def verify( text ) when is_bitstring(text), do: {:ok, text}
     def verify( _ ), do: :invalid_data
 
-    # TODO: Explanation of init/2 callback here.
+    @impl Scenic.Component
     def init( text, opts ) do
         # modify the already built graph
         graph = @graph
@@ -32,6 +32,6 @@ defmodule <%= @app_module_name %>.Components.<%= @component_module_name %> do
         {:ok, state, push: graph}
     end
 
-    # TODO Explanation of event handlers here.
+    @impl Scenic.Component
     def handle_input(_event, _context, state), do: {:noreply, state}
 end

--- a/templates/gen_component/lib/components/component.ex.eex
+++ b/templates/gen_component/lib/components/component.ex.eex
@@ -17,7 +17,6 @@ defmodule <%= @app_module_name %>.Components.<%= @component_module_name %> do
     def verify( text ) when is_bitstring(text), do: {:ok, text}
     def verify( _ ), do: :invalid_data
 
-    @impl Scenic.Component
     def init( text, opts ) do
         # modify the already built graph
         graph = @graph
@@ -32,6 +31,5 @@ defmodule <%= @app_module_name %>.Components.<%= @component_module_name %> do
         {:ok, state, push: graph}
     end
 
-    @impl Scenic.Component
     def handle_input(_event, _context, state), do: {:noreply, state}
 end

--- a/templates/gen_component/lib/components/component.ex.eex
+++ b/templates/gen_component/lib/components/component.ex.eex
@@ -32,5 +32,6 @@ defmodule <%= @component_module %> do
         {:ok, state, push: graph}
     end
 
+    @impl Scenic.Scene
     def handle_input(_event, _context, state), do: {:noreply, state}
 end

--- a/templates/gen_component/lib/components/component.ex.eex
+++ b/templates/gen_component/lib/components/component.ex.eex
@@ -1,4 +1,4 @@
-defmodule <%= @app_module_name %>.Component.<%= @component_module_name %> do  
+defmodule <%= @app_module_name %>.Components.<%= @component_module_name %> do  
     require Logger  
     use Scenic.Component
     import Scenic.Primitives, only: [{:text, 3}, {:update_opts, 2}]

--- a/templates/gen_component/lib/components/component.ex.eex
+++ b/templates/gen_component/lib/components/component.ex.eex
@@ -1,37 +1,48 @@
 defmodule <%= @component_module %> do
-    require Logger  
-    use Scenic.Component
-    import Scenic.Primitives, only: [{:text, 3}, {:update_opts, 2}]
+  require Logger
+  use Scenic.Component
+  import Scenic.Primitives
+  alias Scenic.Graph
 
-    @graph Graph.build()
-    |> text("", text_align: :center, translate: {100, 200}, id: :text)
+  # You can add it to your scene with:
+  #
+  # graph
+  # |> MyApp.Component.#{component_module}.add_to_graph(
+  #   "My Component",
+  #   translate: {100, 100}
+  # )
 
-    @impl Scenic.Component
-    def info( data ), do: """
-    #{IO.ANSI.red()}#{__MODULE__} data must be a bitstring
-    #{IO.ANSI.yellow()}Received: #{inspect(data)}
-    #{IO.ANSI.default_color()}
-    """
+  @graph Graph.build()
+         |> text("", text_align: :center, translate: {100, 200}, id: :text)
 
-    @impl Scenic.Component
-    def verify( text ) when is_bitstring(text), do: {:ok, text}
-    def verify( _ ), do: :invalid_data
+  @impl Scenic.Component
+  def validate(text) when is_bitstring(text), do: {:ok, text}
 
-    @impl Scenic.Scene
-    def init( text, opts ) do
-        # modify the already built graph
-        graph = @graph
-        |> Graph.modify(:_root_, &update_opts(&1, styles: opts[:styles]) )
-        |> Graph.modify(:text, &text(&1, text) )
+  def validate(data) do
+    {:error,
+     """
+     #{IO.ANSI.red()}#{__MODULE__} data must be a bitstring
+     #{IO.ANSI.yellow()}Received: #{inspect(data)}
+     #{IO.ANSI.default_color()}
+     """}
+  end
 
-        state = %{
-        graph: graph,
-        text: text
-        }
+  @impl Scenic.Scene
+  def init(scene, text, opts) do
+    # modify the already built graph
+    graph =
+      @graph
+      |> Graph.modify(:_root_, &update_opts(&1, styles: opts[:styles]))
+      |> Graph.modify(:text, &text(&1, text))
 
-        {:ok, state, push: graph}
-    end
+    scene =
+      scene
+      |> assign(text: text)
+      |> push_graph(graph)
 
-    @impl Scenic.Scene
-    def handle_input(_event, _context, state), do: {:noreply, state}
+    {:ok, scene}
+  end
+
+  @impl Scenic.Scene
+  def handle_input(_event, _context, scene), do: {:noreply, scene}
 end

--- a/templates/gen_component/lib/components/component.ex.eex
+++ b/templates/gen_component/lib/components/component.ex.eex
@@ -1,4 +1,4 @@
-defmodule <%= @component_module %> do  
+defmodule <%= inspect(@component_module) %> do  
     require Logger  
     use Scenic.Component
     import Scenic.Primitives, only: [{:text, 3}, {:update_opts, 2}]

--- a/templates/gen_component/lib/components/component.ex.eex
+++ b/templates/gen_component/lib/components/component.ex.eex
@@ -17,6 +17,7 @@ defmodule <%= @component_module %> do
     def verify( text ) when is_bitstring(text), do: {:ok, text}
     def verify( _ ), do: :invalid_data
 
+    @impl Scenic.Scene
     def init( text, opts ) do
         # modify the already built graph
         graph = @graph

--- a/templates/gen_component/lib/components/component.ex.eex
+++ b/templates/gen_component/lib/components/component.ex.eex
@@ -1,4 +1,4 @@
-defmodule <%= inspect(@component_module) %> do  
+defmodule <%= @component_module %> do
     require Logger  
     use Scenic.Component
     import Scenic.Primitives, only: [{:text, 3}, {:update_opts, 2}]

--- a/templates/gen_component/lib/components/component.ex.eex
+++ b/templates/gen_component/lib/components/component.ex.eex
@@ -1,4 +1,4 @@
-defmodule <%= @app_module_name %>.Components.<%= @component_module_name %> do  
+defmodule <%= @component_module %> do  
     require Logger  
     use Scenic.Component
     import Scenic.Primitives, only: [{:text, 3}, {:update_opts, 2}]

--- a/templates/gen_component/lib/components/component.ex.eex
+++ b/templates/gen_component/lib/components/component.ex.eex
@@ -1,0 +1,37 @@
+defmodule <%= @app_module_name %>.Component.<%= @component_module_name %> do  
+    require Logger  
+    use Scenic.Component
+    import Scenic.Primitives, only: [{:text, 3}, {:update_opts, 2}]
+
+    @graph Graph.build()
+    |> text("", text_align: :center, translate: {100, 200}, id: :text)
+
+    # TODO: Explanation of info/1 callback here.
+    def info( data ), do: """
+    #{IO.ANSI.red()}#{__MODULE__} data must be a bitstring
+    #{IO.ANSI.yellow()}Received: #{inspect(data)}
+    #{IO.ANSI.default_color()}
+    """
+
+    # TODO: Explanation of verify/1 callback here.
+    def verify( text ) when is_bitstring(text), do: {:ok, text}
+    def verify( _ ), do: :invalid_data
+
+    # TODO: Explanation of init/2 callback here.
+    def init( text, opts ) do
+        # modify the already built graph
+        graph = @graph
+        |> Graph.modify(:_root_, &update_opts(&1, styles: opts[:styles]) )
+        |> Graph.modify(:text, &text(&1, text) )
+
+        state = %{
+        graph: graph,
+        text: text
+        }
+
+        {:ok, state, push: graph}
+    end
+
+    # TODO Explanation of event handlers here.
+    def handle_input(_event, _context, state), do: {:noreply, state}
+end

--- a/templates/gen_scene/lib/scenes/scene.ex.eex
+++ b/templates/gen_scene/lib/scenes/scene.ex.eex
@@ -1,4 +1,4 @@
-defmodule <%= @app_module_name %>.Scene.<%= @scene_module_name %> do
+defmodule <%= @scene_module %> do
   use Scenic.Scene
   require Logger
 

--- a/templates/gen_scene/lib/scenes/scene.ex.eex
+++ b/templates/gen_scene/lib/scenes/scene.ex.eex
@@ -10,10 +10,7 @@ defmodule <%= @app_module_name %>.Scene.<%= @scene_module_name %> do
 
   @text_size 24
 
-  # ============================================================================
-  # setup
-
-  # --------------------------------------------------------
+  @impl Scenic.Scene
   def init(_, opts) do
     # get the width and height of the viewport. This is to demonstrate creating
     # a transparent full-screen rectangle to catch user input
@@ -35,6 +32,7 @@ defmodule <%= @app_module_name %>.Scene.<%= @scene_module_name %> do
     {:ok, graph, push: graph}
   end
 
+  @impl Scenic.Scene
   def handle_input(event, _context, state) do
     Logger.info("Received event: #{inspect(event)}")
     {:noreply, state}

--- a/templates/gen_scene/lib/scenes/scene.ex.eex
+++ b/templates/gen_scene/lib/scenes/scene.ex.eex
@@ -1,0 +1,42 @@
+defmodule <%= @app_module_name %>.Scene.<%= @scene_module_name %> do
+  use Scenic.Scene
+  require Logger
+
+  alias Scenic.Graph
+  alias Scenic.ViewPort
+
+  import Scenic.Primitives
+  # import Scenic.Components
+
+  @text_size 24
+
+  # ============================================================================
+  # setup
+
+  # --------------------------------------------------------
+  def init(_, opts) do
+    # get the width and height of the viewport. This is to demonstrate creating
+    # a transparent full-screen rectangle to catch user input
+    {:ok, %ViewPort.Status{size: {width, height}}} = ViewPort.info(opts[:viewport])
+
+    # show the version of scenic and the glfw driver
+    scenic_ver = Application.spec(:scenic, :vsn) |> to_string()
+    glfw_ver = Application.spec(:scenic_driver_glfw, :vsn) |> to_string()
+
+    graph =
+      Graph.build(font: :roboto, font_size: @text_size)
+      |> add_specs_to_graph([
+        text_spec("scenic: v" <> scenic_ver, translate: {20, 40}),
+        text_spec("glfw: v" <> glfw_ver, translate: {20, 40 + @text_size}),
+        text_spec(@note, translate: {20, 120}),
+        rect_spec({width, height})
+      ])
+
+    {:ok, graph, push: graph}
+  end
+
+  def handle_input(event, _context, state) do
+    Logger.info("Received event: #{inspect(event)}")
+    {:noreply, state}
+  end
+end

--- a/templates/gen_scene/lib/scenes/scene.ex.eex
+++ b/templates/gen_scene/lib/scenes/scene.ex.eex
@@ -1,4 +1,4 @@
-defmodule <%= @scene_module %> do
+defmodule <%= inspect(@scene_module) %> do
   use Scenic.Scene
   require Logger
 

--- a/templates/gen_scene/lib/scenes/scene.ex.eex
+++ b/templates/gen_scene/lib/scenes/scene.ex.eex
@@ -3,37 +3,44 @@ defmodule <%= inspect(@scene_module) %> do
   require Logger
 
   alias Scenic.Graph
-  alias Scenic.ViewPort
 
   import Scenic.Primitives
 
   @text_size 24
 
+  @note """
+  This is an example scene generated with
+
+  `mix scenic.gen.scene`
+  """
+
   @impl Scenic.Scene
-  def init(_, opts) do
+  def init(scene, _args, _opts) do
     # get the width and height of the viewport. This is to demonstrate creating
     # a transparent full-screen rectangle to catch user input
-    {:ok, %ViewPort.Status{size: {width, height}}} = ViewPort.info(opts[:viewport])
+    %Scenic.ViewPort{size: {width, height}} = scene.viewport
 
-    # show the version of scenic and the glfw driver
+    # show the version of scenic and the local driver
     scenic_ver = Application.spec(:scenic, :vsn) |> to_string()
-    glfw_ver = Application.spec(:scenic_driver_glfw, :vsn) |> to_string()
+    driver_local_version = Application.spec(:scenic_driver_local, :vsn) |> to_string()
 
     graph =
       Graph.build(font: :roboto, font_size: @text_size)
       |> add_specs_to_graph([
+        rect_spec({width, height}, fill: :clear, input: [:cursor_button, :cursor_pos]),
         text_spec("scenic: v" <> scenic_ver, translate: {20, 40}),
-        text_spec("glfw: v" <> glfw_ver, translate: {20, 40 + @text_size}),
-        text_spec(@note, translate: {20, 120}),
-        rect_spec({width, height})
+        text_spec("local_driver: v" <> driver_local_version, translate: {20, 40 + @text_size}),
+        text_spec(@note, translate: {20, 120})
       ])
 
-    {:ok, graph, push: graph}
+    scene = push_graph(scene, graph)
+
+    {:ok, scene}
   end
 
   @impl Scenic.Scene
-  def handle_input(event, _context, state) do
+  def handle_input(event, _context, scene) do
     Logger.info("Received event: #{inspect(event)}")
-    {:noreply, state}
+    {:noreply, scene}
   end
 end

--- a/templates/gen_scene/lib/scenes/scene.ex.eex
+++ b/templates/gen_scene/lib/scenes/scene.ex.eex
@@ -6,7 +6,6 @@ defmodule <%= @app_module_name %>.Scene.<%= @scene_module_name %> do
   alias Scenic.ViewPort
 
   import Scenic.Primitives
-  # import Scenic.Components
 
   @text_size 24
 

--- a/templates/gitignore
+++ b/templates/gitignore
@@ -26,3 +26,6 @@ foo-*.tar
 # Ignore scripts marked as secret - usually passwords and such in config files
 *.secret.exs
 *.secrets.exs
+
+# Ignore generated static Scenic asset files
+priv/__scenic/

--- a/templates/new/config/config.exs.eex
+++ b/templates/new/config/config.exs.eex
@@ -3,18 +3,23 @@
 use Mix.Config
 
 # Configure the main viewport for the Scenic application
-config :<%= @app %>, :viewport, %{
+config :<%= @app %>, :viewport,
   name: :main_viewport,
   size: {700, 600},
   default_scene: {<%= @mod %>.Scene.Home, nil},
   drivers: [
-    %{
-      module: Scenic.Driver.Glfw,
-      name: :glfw,
-      opts: [resizeable: false, title: "<%= @app %>"]
-    }
+    [
+      module: Scenic.Driver.Local,
+      name: :local,
+      window: [
+        title: "<%= @app %>",
+        resizeable: true
+      ],
+      on_close: :stop_system
+    ]
   ]
-}
+
+config :scenic, :assets, module: <%= @mod %>.Assets
 
 # It is also possible to import configuration files, relative to this
 # directory. For example, you can emulate configuration per environment

--- a/templates/new/lib/app.ex.eex
+++ b/templates/new/lib/app.ex.eex
@@ -9,7 +9,7 @@ defmodule <%= @mod %> do
 
     # start the application with the viewport
     children = [
-      {Scenic, viewports: [main_viewport_config]}
+      {Scenic, [main_viewport_config]}
     ]
 
     Supervisor.start_link(children, strategy: :one_for_one)

--- a/templates/new/lib/assets.ex.eex
+++ b/templates/new/lib/assets.ex.eex
@@ -1,0 +1,3 @@
+defmodule <%= @mod %>.Assets do
+  use Scenic.Assets.Static, otp_app: :<%= @app %>
+end

--- a/templates/new/lib/scenes/home.ex.eex
+++ b/templates/new/lib/scenes/home.ex.eex
@@ -3,17 +3,16 @@ defmodule <%= @mod %>.Scene.Home do
   require Logger
 
   alias Scenic.Graph
-  alias Scenic.ViewPort
 
   import Scenic.Primitives
   # import Scenic.Components
 
   @note """
-    This is a very simple starter application.
+  This is a very simple starter application.
 
-    If you want a more full-on example, please start from:
+  If you want a more full-on example, please start from:
 
-    mix scenic.new.example
+  mix scenic.new.example
   """
 
   @text_size 24
@@ -22,25 +21,30 @@ defmodule <%= @mod %>.Scene.Home do
   # setup
 
   # --------------------------------------------------------
-  def init(_, opts) do
+  def init(scene, _opts, _scenic_opts) do
     # get the width and height of the viewport. This is to demonstrate creating
     # a transparent full-screen rectangle to catch user input
-    {:ok, %ViewPort.Status{size: {width, height}}} = ViewPort.info(opts[:viewport])
+    %Scenic.ViewPort{size: {width, height}} = scene.viewport
 
-    # show the version of scenic and the glfw driver
+    # This is required if you want to detect when the user presses a key on their keyboard
+    Scenic.Scene.capture_input(scene, [:key])
+
+    # These variables will be used to show the version of scenic and the local driver
     scenic_ver = Application.spec(:scenic, :vsn) |> to_string()
-    glfw_ver = Application.spec(:scenic_driver_glfw, :vsn) |> to_string()
+    driver_local_version = Application.spec(:scenic_driver_local, :vsn) |> to_string()
 
     graph =
       Graph.build(font: :roboto, font_size: @text_size)
       |> add_specs_to_graph([
+        rect_spec({width, height}, fill: :clear, input: [:cursor_button, :cursor_pos]),
         text_spec("scenic: v" <> scenic_ver, translate: {20, 40}),
-        text_spec("glfw: v" <> glfw_ver, translate: {20, 40 + @text_size}),
-        text_spec(@note, translate: {20, 120}),
-        rect_spec({width, height})
+        text_spec("local_driver: v" <> driver_local_version, translate: {20, 40 + @text_size}),
+        text_spec(@note, translate: {20, 120})
       ])
 
-    {:ok, graph, push: graph}
+    scene = push_graph(scene, graph)
+
+    {:ok, scene}
   end
 
   def handle_input(event, _context, state) do

--- a/templates/new/mix.exs.eex
+++ b/templates/new/mix.exs.eex
@@ -23,7 +23,7 @@ defmodule <%= @mod %>.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:scenic, github: "boydm/scenic", branch: "v0.11"},
+      {:scenic, "~> 0.11.0-beta.0"},
       {:scenic_driver_local, github: "ScenicFramework/scenic_driver_local"}
     ]
   end

--- a/templates/new/mix.exs.eex
+++ b/templates/new/mix.exs.eex
@@ -6,7 +6,7 @@ defmodule <%= @mod %>.MixProject do
       app: :<%= @app %>,
       version: "0.1.0",
       elixir: "~> 1.7",
-      build_embedded: true,
+      build_embedded: false,
       start_permanent: Mix.env() == :prod,
       deps: deps()
     ]
@@ -23,8 +23,8 @@ defmodule <%= @mod %>.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:scenic, "~> 0.10"},
-      {:scenic_driver_glfw, "~> 0.10", targets: :host},
+      {:scenic, github: "boydm/scenic", branch: "v0.11"},
+      {:scenic_driver_local, github: "ScenicFramework/scenic_driver_local"}
     ]
   end
 end

--- a/templates/new_example/mix.exs.eex
+++ b/templates/new_example/mix.exs.eex
@@ -24,7 +24,7 @@ defmodule <%= @mod %>.MixProject do
   defp deps do
     [
       {:scenic, "~> 0.10"},
-      {:scenic_driver_glfw, "~> 0.10", targets: :host},
+      {:scenic_driver_local, "~> 0.1", targets: :host},
 
       # These deps are optional and are included as they are often used.
       # If your app doesn't need them, they are safe to remove.

--- a/templates/new_nerves/mix.exs.eex
+++ b/templates/new_nerves/mix.exs.eex
@@ -47,7 +47,7 @@ defmodule <%= @mod %>.MixProject do
       {:scenic_sensor, "~> 0.7"},
 
       # Dependencies for only the :host
-      {:scenic_driver_glfw, "~> 0.10", targets: :host},
+      {:scenic_driver_local, "~> 0.1", targets: :host},
 
       # Dependencies for all targets except :host
       {:nerves_runtime, "~> 0.9", targets: @all_targets},

--- a/test/mix_helper.exs
+++ b/test/mix_helper.exs
@@ -4,7 +4,7 @@ defmodule ScenicNew.MixHelper do
   import ExUnit.Assertions
 
   def tmp_path do
-    Path.expand("../../tmp", __DIR__)
+    Path.expand("../tmp", __DIR__)
   end
 
   defp random_string(len) do
@@ -19,7 +19,8 @@ defmodule ScenicNew.MixHelper do
       File.mkdir_p!(path)
       File.cd!(path, function)
     after
-      File.rm_rf!(path)
+      path |> Path.dirname() |> File.rm_rf!()
+      tmp_path() |> File.rm_rf!()
     end
   end
 

--- a/test/scenic_gen_component_test.exs
+++ b/test/scenic_gen_component_test.exs
@@ -15,16 +15,16 @@ defmodule Mix.Tasks.Scenic.Gen.ComponentTest do
   test "gen.scene" do
     Application.put_env(String.to_atom(@app_name), :namespace, String.to_atom(@module_name))
 
+    func = fn ->
+      Mix.Tasks.Scenic.New.run([@app_name])
+      Mix.Tasks.Scenic.Gen.Component.run([@component_module_name])
+
+      assert_file("lib/components/#{@component_name}.ex", fn file ->
+        assert file =~ "defmodule #{@module_name}.Components.#{@component_module_name} do"
+      end)
+    end
+
     in_tmp("new with defaults", fn ->
-      func = fn ->
-        Mix.Tasks.Scenic.New.run([@app_name])
-        Mix.Tasks.Scenic.Gen.Component.run([@component_module_name])
-
-        assert_file("lib/components/#{@component_name}.ex", fn file ->
-          assert file =~ "defmodule #{@module_name}.Components.#{@component_module_name} do"
-        end)
-      end
-
       assert capture_io(func) =~ "Created component #{@component_module_name}."
     end)
   end

--- a/test/scenic_gen_component_test.exs
+++ b/test/scenic_gen_component_test.exs
@@ -15,7 +15,6 @@ defmodule Mix.Tasks.Scenic.Gen.ComponentTest do
 
   test "gen.scene" do
     Application.put_env(String.to_atom(@app_name), :namespace, String.to_atom(@module_name))
-    IO.inspect(Application.get_all_env(String.to_atom(@app_name)), label: "APP ENV")
     in_tmp("new with defaults", fn ->
       func = fn ->
         Mix.Tasks.Scenic.New.run([@app_name])

--- a/test/scenic_gen_component_test.exs
+++ b/test/scenic_gen_component_test.exs
@@ -9,18 +9,16 @@ defmodule Mix.Tasks.Scenic.Gen.ComponentTest do
 
   @component_name "test_component"
   @component_module_name "TestComponent"
-  @app_name "scenic_demo"
-  @module_name "ScenicDemo"
+  @app_name "scenic_new"
+  @module_name "ScenicNew"
 
   test "gen.scene" do
-    Application.put_env(String.to_atom(@app_name), :namespace, String.to_atom(@module_name))
-
     func = fn ->
       Mix.Tasks.Scenic.New.run([@app_name])
       Mix.Tasks.Scenic.Gen.Component.run([@component_module_name])
 
       assert_file("lib/components/#{@component_name}.ex", fn file ->
-        assert file =~ "defmodule #{@module_name}.Components.#{@component_module_name} do"
+        assert file =~ "defmodule #{@module_name}.Component.#{@component_module_name} do"
       end)
     end
 

--- a/test/scenic_gen_component_test.exs
+++ b/test/scenic_gen_component_test.exs
@@ -4,7 +4,6 @@ defmodule Mix.Tasks.Scenic.Gen.ComponentTest do
   use ExUnit.Case, async: false
   @moduletag :gen_component
 
-
   import ScenicNew.MixHelper
   import ExUnit.CaptureIO
 
@@ -15,6 +14,7 @@ defmodule Mix.Tasks.Scenic.Gen.ComponentTest do
 
   test "gen.scene" do
     Application.put_env(String.to_atom(@app_name), :namespace, String.to_atom(@module_name))
+
     in_tmp("new with defaults", fn ->
       func = fn ->
         Mix.Tasks.Scenic.New.run([@app_name])

--- a/test/scenic_gen_component_test.exs
+++ b/test/scenic_gen_component_test.exs
@@ -7,23 +7,23 @@ defmodule Mix.Tasks.Scenic.Gen.ComponentTest do
   import ScenicNew.MixHelper
   import ExUnit.CaptureIO
 
-  @component_name "test_component"
-  @component_module_name "TestComponent"
+  @app_module "ScenicNew"
   @app_name "scenic_new"
-  @module_name "ScenicNew"
+  @component_module "TestComponent"
+  @component_name "test_component"
 
   test "gen.scene" do
     func = fn ->
       Mix.Tasks.Scenic.New.run([@app_name])
-      Mix.Tasks.Scenic.Gen.Component.run([@component_module_name])
+      Mix.Tasks.Scenic.Gen.Component.run([@component_module])
 
       assert_file("lib/components/#{@component_name}.ex", fn file ->
-        assert file =~ "defmodule #{@module_name}.Component.#{@component_module_name} do"
+        assert file =~ "defmodule #{@app_module}.Component.#{@component_module} do"
       end)
     end
 
     in_tmp("new with defaults", fn ->
-      assert capture_io(func) =~ "Created component #{@component_module_name}."
+      assert capture_io(func) =~ "Created component #{@component_module}."
     end)
   end
 

--- a/test/scenic_gen_component_test.exs
+++ b/test/scenic_gen_component_test.exs
@@ -1,0 +1,67 @@
+Code.require_file("mix_helper.exs", __DIR__)
+
+defmodule Mix.Tasks.Scenic.Gen.ComponentTest do
+  use ExUnit.Case, async: false
+  @moduletag :gen_component
+
+
+  import ScenicNew.MixHelper
+  import ExUnit.CaptureIO
+
+  @component_name "test_component"
+  @component_module_name "TestComponent"
+  @app_name "scenic_demo"
+  @module_name "ScenicDemo"
+
+  test "gen.scene" do
+    Application.put_env(String.to_atom(@app_name), :namespace, String.to_atom(@module_name))
+    IO.inspect(Application.get_all_env(String.to_atom(@app_name)), label: "APP ENV")
+    in_tmp("new with defaults", fn ->
+      func = fn ->
+        Mix.Tasks.Scenic.New.run([@app_name])
+        Mix.Tasks.Scenic.Gen.Component.run([@component_module_name])
+
+        assert_file("lib/components/#{@component_name}.ex", fn file ->
+          assert file =~ "defmodule #{@module_name}.Components.#{@component_module_name} do"
+        end)
+      end
+
+      assert capture_io(func) =~ "Created component #{@component_module_name}."
+    end)
+  end
+
+  # test "new with invalid args" do
+  #   assert_raise Mix.Error, ~r"Application name must start with a lowercase ASCII letter,", fn ->
+  #     Mix.Tasks.Scenic.Gen.Scene.run(["007invalid"])
+  #   end
+
+  #   assert_raise Mix.Error, ~r"Application name must start with a lowercase ASCII letter, ", fn ->
+  #     Mix.Tasks.Scenic.Gen.Scene.run(["valid", "--app", "007invalid"])
+  #   end
+
+  #   assert_raise Mix.Error, ~r"Module name must be a valid Elixir alias", fn ->
+  #     Mix.Tasks.Scenic.Gen.Scene.run(["valid", "--module", "not.valid"])
+  #   end
+
+  #   assert_raise Mix.Error, ~r"Module name \w+ is already taken", fn ->
+  #     Mix.Tasks.Scenic.Gen.Scene.run(["string"])
+  #   end
+
+  #   assert_raise Mix.Error, ~r"Module name \w+ is already taken", fn ->
+  #     Mix.Tasks.Scenic.Gen.Scene.run(["string", "chars"])
+  #   end
+
+  #   assert_raise Mix.Error, ~r"Module name \w+ is already taken", fn ->
+  #     Mix.Tasks.Scenic.Gen.Scene.run(["valid", "--app", "mix"])
+  #   end
+
+  #   assert_raise Mix.Error, ~r"Module name \w+ is already taken", fn ->
+  #     Mix.Tasks.Scenic.Gen.Scene.run(["valid", "--module", "String"])
+  #   end
+  # end
+
+  # test "new without args" do
+  #   assert capture_io(fn -> Mix.Tasks.Scenic.Gen.Scene.run([]) end) =~
+  #   "Generates Scene boilerplate for a new scene."
+  # end
+end

--- a/test/scenic_gen_scene_test.exs
+++ b/test/scenic_gen_scene_test.exs
@@ -14,15 +14,16 @@ defmodule Mix.Tasks.Scenic.Gen.SceneTest do
   @module_name "ScenicDemo"
 
   test "gen.scene" do
-     in_tmp("new with defaults", fn ->
+    in_tmp("new with defaults", fn ->
        assert capture_io(fn ->
-      Mix.Tasks.Scenic.Gen.Scene.run([@scene_name])
+        Mix.Tasks.Scenic.New.run([@app_name])
+        Mix.Tasks.Scenic.Gen.Scene.run([@scene_name])
 
-      assert_file("lib/scenes/#{@scene_name}.ex", fn file ->
-        assert file =~ "defmodule #{@scene_module_name} do"
-      end)
-    end) =~ "Created component #{@scene_module_name}."
-  end)
+        assert_file("lib/scenes/#{@scene_name}.ex", fn file ->
+          assert file =~ "defmodule #{@module_name}.Component.#{@scene_module_name} do"
+        end)
+      end) =~ "Created component #{@scene_module_name}."
+    end)
   end
 
   # test "new with invalid args" do

--- a/test/scenic_gen_scene_test.exs
+++ b/test/scenic_gen_scene_test.exs
@@ -1,0 +1,62 @@
+Code.require_file("mix_helper.exs", __DIR__)
+
+defmodule Mix.Tasks.Scenic.Gen.SceneTest do
+  use ExUnit.Case, async: false
+  @moduletag :gen_scene
+
+
+  import ScenicNew.MixHelper
+  import ExUnit.CaptureIO
+
+  @scene_name "test_scene"
+  @scene_module_name "TestScene"
+  @app_name "scenic_demo"
+  @module_name "ScenicDemo"
+
+  test "gen.scene" do
+     in_tmp("new with defaults", fn ->
+       assert capture_io(fn ->
+      Mix.Tasks.Scenic.Gen.Scene.run([@scene_name])
+
+      assert_file("lib/scenes/#{@scene_name}.ex", fn file ->
+        assert file =~ "defmodule #{@scene_module_name} do"
+      end)
+    end) =~ "Created component #{@scene_module_name}."
+  end)
+  end
+
+  # test "new with invalid args" do
+  #   assert_raise Mix.Error, ~r"Application name must start with a lowercase ASCII letter,", fn ->
+  #     Mix.Tasks.Scenic.Gen.Scene.run(["007invalid"])
+  #   end
+
+  #   assert_raise Mix.Error, ~r"Application name must start with a lowercase ASCII letter, ", fn ->
+  #     Mix.Tasks.Scenic.Gen.Scene.run(["valid", "--app", "007invalid"])
+  #   end
+
+  #   assert_raise Mix.Error, ~r"Module name must be a valid Elixir alias", fn ->
+  #     Mix.Tasks.Scenic.Gen.Scene.run(["valid", "--module", "not.valid"])
+  #   end
+
+  #   assert_raise Mix.Error, ~r"Module name \w+ is already taken", fn ->
+  #     Mix.Tasks.Scenic.Gen.Scene.run(["string"])
+  #   end
+
+  #   assert_raise Mix.Error, ~r"Module name \w+ is already taken", fn ->
+  #     Mix.Tasks.Scenic.Gen.Scene.run(["string", "chars"])
+  #   end
+
+  #   assert_raise Mix.Error, ~r"Module name \w+ is already taken", fn ->
+  #     Mix.Tasks.Scenic.Gen.Scene.run(["valid", "--app", "mix"])
+  #   end
+
+  #   assert_raise Mix.Error, ~r"Module name \w+ is already taken", fn ->
+  #     Mix.Tasks.Scenic.Gen.Scene.run(["valid", "--module", "String"])
+  #   end
+  # end
+
+  # test "new without args" do
+  #   assert capture_io(fn -> Mix.Tasks.Scenic.Gen.Scene.run([]) end) =~
+  #   "Generates Scene boilerplate for a new scene."
+  # end
+end

--- a/test/scenic_gen_scene_test.exs
+++ b/test/scenic_gen_scene_test.exs
@@ -15,14 +15,17 @@ defmodule Mix.Tasks.Scenic.Gen.SceneTest do
 
   test "gen.scene" do
     in_tmp("new with defaults", fn ->
-       assert capture_io(fn ->
+      func = fn ->
         Mix.Tasks.Scenic.New.run([@app_name])
+        Application.put_env(String.to_atom(@app_name), :namespace, String.to_atom(@module_name))
         Mix.Tasks.Scenic.Gen.Scene.run([@scene_name])
 
         assert_file("lib/scenes/#{@scene_name}.ex", fn file ->
           assert file =~ "defmodule #{@module_name}.Component.#{@scene_module_name} do"
         end)
-      end) =~ "Created component #{@scene_module_name}."
+      end
+
+      assert capture_io(func) =~ "Created component #{@scene_module_name}."
     end)
   end
 

--- a/test/scenic_gen_scene_test.exs
+++ b/test/scenic_gen_scene_test.exs
@@ -15,16 +15,16 @@ defmodule Mix.Tasks.Scenic.Gen.SceneTest do
   test "gen.scene" do
     Application.put_env(String.to_atom(@app_name), :namespace, String.to_atom(@module_name))
 
+    func = fn ->
+      Mix.Tasks.Scenic.New.run([@app_name])
+      Mix.Tasks.Scenic.Gen.Scene.run([@scene_module_name])
+
+      assert_file("lib/scenes/#{@scene_name}.ex", fn file ->
+        assert file =~ "defmodule #{@module_name}.Scene.#{@scene_module_name} do"
+      end)
+    end
+
     in_tmp("new with defaults", fn ->
-      func = fn ->
-        Mix.Tasks.Scenic.New.run([@app_name])
-        Mix.Tasks.Scenic.Gen.Scene.run([@scene_module_name])
-
-        assert_file("lib/scenes/#{@scene_name}.ex", fn file ->
-          assert file =~ "defmodule #{@module_name}.Scene.#{@scene_module_name} do"
-        end)
-      end
-
       assert capture_io(func) =~ "Created scene #{@scene_module_name}."
     end)
   end

--- a/test/scenic_gen_scene_test.exs
+++ b/test/scenic_gen_scene_test.exs
@@ -15,7 +15,6 @@ defmodule Mix.Tasks.Scenic.Gen.SceneTest do
 
   test "gen.scene" do
     Application.put_env(String.to_atom(@app_name), :namespace, String.to_atom(@module_name))
-    IO.inspect(Application.get_all_env(String.to_atom(@app_name)), label: "APP ENV")
     in_tmp("new with defaults", fn ->
       func = fn ->
         Mix.Tasks.Scenic.New.run([@app_name])

--- a/test/scenic_gen_scene_test.exs
+++ b/test/scenic_gen_scene_test.exs
@@ -7,23 +7,23 @@ defmodule Mix.Tasks.Scenic.Gen.SceneTest do
   import ScenicNew.MixHelper
   import ExUnit.CaptureIO
 
-  @scene_name "test_scene"
-  @scene_module_name "TestScene"
+  @app_module "ScenicNew"
   @app_name "scenic_new"
-  @module_name "ScenicNew"
+  @scene_module "TestScene"
+  @scene_name "test_scene"
 
   test "gen.scene" do
     func = fn ->
       Mix.Tasks.Scenic.New.run([@app_name])
-      Mix.Tasks.Scenic.Gen.Scene.run([@scene_module_name])
+      Mix.Tasks.Scenic.Gen.Scene.run([@scene_module])
 
       assert_file("lib/scenes/#{@scene_name}.ex", fn file ->
-        assert file =~ "defmodule #{@module_name}.Scene.#{@scene_module_name} do"
+        assert file =~ "defmodule #{@app_module}.Scene.#{@scene_module} do"
       end)
     end
 
     in_tmp("new with defaults", fn ->
-      assert capture_io(func) =~ "Created scene #{@scene_module_name}."
+      assert capture_io(func) =~ "Created scene #{@scene_module}."
     end)
   end
 

--- a/test/scenic_gen_scene_test.exs
+++ b/test/scenic_gen_scene_test.exs
@@ -9,12 +9,10 @@ defmodule Mix.Tasks.Scenic.Gen.SceneTest do
 
   @scene_name "test_scene"
   @scene_module_name "TestScene"
-  @app_name "scenic_demo"
-  @module_name "ScenicDemo"
+  @app_name "scenic_new"
+  @module_name "ScenicNew"
 
   test "gen.scene" do
-    Application.put_env(String.to_atom(@app_name), :namespace, String.to_atom(@module_name))
-
     func = fn ->
       Mix.Tasks.Scenic.New.run([@app_name])
       Mix.Tasks.Scenic.Gen.Scene.run([@scene_module_name])

--- a/test/scenic_gen_scene_test.exs
+++ b/test/scenic_gen_scene_test.exs
@@ -4,7 +4,6 @@ defmodule Mix.Tasks.Scenic.Gen.SceneTest do
   use ExUnit.Case, async: false
   @moduletag :gen_scene
 
-
   import ScenicNew.MixHelper
   import ExUnit.CaptureIO
 
@@ -15,6 +14,7 @@ defmodule Mix.Tasks.Scenic.Gen.SceneTest do
 
   test "gen.scene" do
     Application.put_env(String.to_atom(@app_name), :namespace, String.to_atom(@module_name))
+
     in_tmp("new with defaults", fn ->
       func = fn ->
         Mix.Tasks.Scenic.New.run([@app_name])

--- a/test/scenic_gen_scene_test.exs
+++ b/test/scenic_gen_scene_test.exs
@@ -7,58 +7,47 @@ defmodule Mix.Tasks.Scenic.Gen.SceneTest do
   import ScenicNew.MixHelper
   import ExUnit.CaptureIO
 
-  @app_module "ScenicNew"
-  @app_name "scenic_new"
   @scene_module "TestScene"
   @scene_name "test_scene"
 
   test "gen.scene" do
-    func = fn ->
-      Mix.Tasks.Scenic.New.run([@app_name])
-      Mix.Tasks.Scenic.Gen.Scene.run([@scene_module])
-
-      assert_file("lib/scenes/#{@scene_name}.ex", fn file ->
-        assert file =~ "defmodule #{@app_module}.Scene.#{@scene_module} do"
-      end)
-    end
-
-    in_tmp("new with defaults", fn ->
-      assert capture_io(func) =~ "Created scene #{@scene_module}."
+    in_project("new with defaults", "my_app", fn _mix_project ->
+      output = capture_io(fn -> Mix.Tasks.Scenic.Gen.Scene.run([@scene_module]) end)
+      module_definition = "defmodule MyApp.Scene.#{@scene_module} do"
+      assert_file("lib/scenes/#{@scene_name}.ex", module_definition)
+      assert output =~ "Created scene #{@scene_module}."
     end)
   end
 
-  # test "new with invalid args" do
-  #   assert_raise Mix.Error, ~r"Application name must start with a lowercase ASCII letter,", fn ->
-  #     Mix.Tasks.Scenic.Gen.Scene.run(["007invalid"])
-  #   end
+  test "gen.scene inside umbrella" do
+    in_project("umbrella", "my_umbrella", ["--umbrella"], Mix.Tasks.New, fn _mix_project ->
+      func = fn -> Mix.Tasks.Scenic.Gen.Scene.run([]) end
+      assert_raise Mix.Error, func
+    end)
+  end
 
-  #   assert_raise Mix.Error, ~r"Application name must start with a lowercase ASCII letter, ", fn ->
-  #     Mix.Tasks.Scenic.Gen.Scene.run(["valid", "--app", "007invalid"])
-  #   end
+  test "gen.scene with app" do
+    in_project("new with app", "my_app", ["--module", "My.App"], fn _mix_project ->
+      args = [@scene_module, "--app", "My.App"]
+      output = capture_io(fn -> Mix.Tasks.Scenic.Gen.Scene.run(args) end)
+      assert output =~ "Created scene #{@scene_module}."
+      module_definition = "defmodule My.App.Scene.#{@scene_module} do"
+      assert_file("lib/scenes/#{@scene_name}.ex", module_definition)
+    end)
+  end
 
-  #   assert_raise Mix.Error, ~r"Module name must be a valid Elixir alias", fn ->
-  #     Mix.Tasks.Scenic.Gen.Scene.run(["valid", "--module", "not.valid"])
-  #   end
+  test "gen.scene without args displays help" do
+    in_project("help", "help", fn _mix_project ->
+      output1 = capture_io(fn -> Mix.Tasks.Scenic.Gen.Scene.run([]) end)
+      output2 = capture_io(fn -> Mix.Tasks.Help.run(["scenic.gen.scene"]) end)
+      assert output1 == output2
+    end)
+  end
 
-  #   assert_raise Mix.Error, ~r"Module name \w+ is already taken", fn ->
-  #     Mix.Tasks.Scenic.Gen.Scene.run(["string"])
-  #   end
-
-  #   assert_raise Mix.Error, ~r"Module name \w+ is already taken", fn ->
-  #     Mix.Tasks.Scenic.Gen.Scene.run(["string", "chars"])
-  #   end
-
-  #   assert_raise Mix.Error, ~r"Module name \w+ is already taken", fn ->
-  #     Mix.Tasks.Scenic.Gen.Scene.run(["valid", "--app", "mix"])
-  #   end
-
-  #   assert_raise Mix.Error, ~r"Module name \w+ is already taken", fn ->
-  #     Mix.Tasks.Scenic.Gen.Scene.run(["valid", "--module", "String"])
-  #   end
-  # end
-
-  # test "new without args" do
-  #   assert capture_io(fn -> Mix.Tasks.Scenic.Gen.Scene.run([]) end) =~
-  #   "Generates Scene boilerplate for a new scene."
-  # end
+  defp in_project(tmp_dir, app_name, extra_args \\ [], task \\ Mix.Tasks.Scenic.New, project_func) do
+    in_tmp(tmp_dir, fn ->
+      capture_io(fn -> task.run([app_name | extra_args]) end)
+      app_name |> String.to_atom() |> Mix.Project.in_project(app_name, project_func)
+    end)
+  end
 end

--- a/test/scenic_gen_scene_test.exs
+++ b/test/scenic_gen_scene_test.exs
@@ -14,18 +14,19 @@ defmodule Mix.Tasks.Scenic.Gen.SceneTest do
   @module_name "ScenicDemo"
 
   test "gen.scene" do
+    Application.put_env(String.to_atom(@app_name), :namespace, String.to_atom(@module_name))
+    IO.inspect(Application.get_all_env(String.to_atom(@app_name)), label: "APP ENV")
     in_tmp("new with defaults", fn ->
       func = fn ->
         Mix.Tasks.Scenic.New.run([@app_name])
-        Application.put_env(String.to_atom(@app_name), :namespace, String.to_atom(@module_name))
-        Mix.Tasks.Scenic.Gen.Scene.run([@scene_name])
+        Mix.Tasks.Scenic.Gen.Scene.run([@scene_module_name])
 
         assert_file("lib/scenes/#{@scene_name}.ex", fn file ->
-          assert file =~ "defmodule #{@module_name}.Component.#{@scene_module_name} do"
+          assert file =~ "defmodule #{@module_name}.Scene.#{@scene_module_name} do"
         end)
       end
 
-      assert capture_io(func) =~ "Created component #{@scene_module_name}."
+      assert capture_io(func) =~ "Created scene #{@scene_module_name}."
     end)
   end
 

--- a/test/scenic_new_example_test.exs
+++ b/test/scenic_new_example_test.exs
@@ -52,7 +52,7 @@ defmodule Mix.Tasks.Scenic.NewExampleTest do
                  assert file =~ "mod: {#{@module_name}, []}"
 
                  assert file =~ "{:scenic, \"~> 0.10\"}"
-                 assert file =~ "{:scenic_driver_glfw, \"~> 0.10\", targets: :host}"
+                 assert file =~ "{:scenic_driver_local, \"~> 0.1\", targets: :host}"
                end)
              end) =~ "Your Scenic project was created successfully."
     end)

--- a/test/scenic_new_nerves_test.exs
+++ b/test/scenic_new_nerves_test.exs
@@ -52,7 +52,7 @@ defmodule Mix.Tasks.Scenic.New.NervesTest do
 
                assert_file("#{@app_name}/mix.exs", fn file ->
                  assert file =~ "{:scenic, \"~> 0.10\"}"
-                 assert file =~ "{:scenic_driver_glfw, \"~> 0.10\", targets: :host}"
+                 assert file =~ "{:scenic_driver_local, \"~> 0.1\", targets: :host}"
 
                  assert file =~
                           "{:scenic_driver_nerves_touch, \"~> 0.10\", targets: @all_targets}"

--- a/test/scenic_new_test.exs
+++ b/test/scenic_new_test.exs
@@ -37,10 +37,8 @@ defmodule Mix.Tasks.Scenic.NewTest do
                assert_file("#{@app_name}/mix.exs", fn file ->
                  assert file =~ "mod: {#{@module_name}, []}"
 
-                 # assert file =~ "{:scenic, \"~> 0.10\"}"
-                 assert file =~ "{:scenic, github: \"boydm/scenic\", branch: \"v0.11\"}"
+                 assert file =~ "{:scenic, \"~> 0.11.0-beta.0\"}"
 
-                 # assert file =~ "{:scenic_driver_local, \"~> 0.1\"}"
                  assert file =~ "{:scenic_driver_local, github: \"ScenicFramework/scenic_driver_local\"}"
                end)
              end) =~ "Your Scenic project was created successfully."

--- a/test/scenic_new_test.exs
+++ b/test/scenic_new_test.exs
@@ -24,7 +24,7 @@ defmodule Mix.Tasks.Scenic.NewTest do
 
                  assert file =~ "default_scene: {#{@module_name}.Scene.Home, nil}"
 
-                 assert file =~ ", title: \"#{@app_name}\""
+                 assert file =~ "title: \"#{@app_name}\""
                end)
 
                assert_file("#{@app_name}/lib/#{@app_name}.ex", fn file ->
@@ -37,8 +37,11 @@ defmodule Mix.Tasks.Scenic.NewTest do
                assert_file("#{@app_name}/mix.exs", fn file ->
                  assert file =~ "mod: {#{@module_name}, []}"
 
-                 assert file =~ "{:scenic, \"~> 0.10\"}"
-                 assert file =~ "{:scenic_driver_glfw, \"~> 0.10\", targets: :host}"
+                 # assert file =~ "{:scenic, \"~> 0.10\"}"
+                 assert file =~ "{:scenic, github: \"boydm/scenic\", branch: \"v0.11\"}"
+
+                 # assert file =~ "{:scenic_driver_local, \"~> 0.1\"}"
+                 assert file =~ "{:scenic_driver_local, github: \"ScenicFramework/scenic_driver_local\"}"
                end)
              end) =~ "Your Scenic project was created successfully."
     end)


### PR DESCRIPTION
This PR is about adding `mix scenic.gen.scene` and `mix scenic.gen.component` helpers.

It's currently a work in progress, but if this is looking like a good idea we can wrap it up.

Current questions are:

* How to we get the proper base module name, e.g.  `MyApp` in `MyApp.Scenes.SceneName` when we've run `mix scenic.gen.scene scene_name`?
* Are there additional considerations around umbrella apps or whatever?