### PR TITLE
Switch from Mix.Config to Config

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,6 +1,6 @@
 # This file is responsible for configuring your application
-# and its dependencies with the aid of the Mix.Config module.
-use Mix.Config
+# and its dependencies with the aid of the Config module.
+import Config
 
 # This configuration is loaded before any dependency and is restricted
 # to this project. If another project depends on this project, this

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule ScenicNew.MixProject do
     [
       app: :scenic_new,
       version: @version,
-      elixir: "~> 1.7",
+      elixir: "~> 1.9",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       aliases: aliases(),

--- a/templates/new/config/config.exs.eex
+++ b/templates/new/config/config.exs.eex
@@ -1,6 +1,6 @@
 # This file is responsible for configuring your application
-# and its dependencies with the aid of the Mix.Config module.
-use Mix.Config
+# and its dependencies with the aid of the Config module.
+import Config
 
 
 # connect the app's asset module to Scenic

--- a/templates/new/mix.exs.eex
+++ b/templates/new/mix.exs.eex
@@ -5,7 +5,7 @@ defmodule <%= @mod %>.MixProject do
     [
       app: :<%= @app %>,
       version: "0.1.0",
-      elixir: "~> 1.7",
+      elixir: "~> 1.9",
       build_embedded: true,
       start_permanent: Mix.env() == :prod,
       deps: deps()

--- a/templates/new_example/config/config.exs.eex
+++ b/templates/new_example/config/config.exs.eex
@@ -1,6 +1,6 @@
 # This file is responsible for configuring your application
-# and its dependencies with the aid of the Mix.Config module.
-use Mix.Config
+# and its dependencies with the aid of the Config module.
+import Config
 
 
 # connect the app's asset module to Scenic

--- a/templates/new_example/mix.exs.eex
+++ b/templates/new_example/mix.exs.eex
@@ -5,7 +5,7 @@ defmodule <%= @mod %>.MixProject do
     [
       app: :<%= @app %>,
       version: "0.1.0",
-      elixir: "~> 1.7",
+      elixir: "~> 1.9",
       build_embedded: true,
       start_permanent: Mix.env() == :prod,
       deps: deps()


### PR DESCRIPTION
Switch from `Mix.Config` to `Config` for both this project and generated projects

Docs:
https://hexdocs.pm/elixir/1.13.4/Config.html#module-migrating-from-use-mix-config

This also bumps the minimum of both the `scenic_new` and generated projects to Elixir 1.9 which was released on 2019-06-24 (and matches the old scenic nerves generator)